### PR TITLE
Fix ZWave light brightness

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -61,7 +61,7 @@ def get_device(node, values, node_config, **kwargs):
 def brightness_state(value):
     """Return the brightness and state."""
     if value.data > 0:
-        return round((value.data / 99) * 255, 0), STATE_ON
+        return int((value.data / 99) * 255), STATE_ON
     return 0, STATE_OFF
 
 


### PR DESCRIPTION
## Description:
The brightness should always be an integer


**Related issue (if applicable):** fixes #14189

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


Reported by @spacesuitdiver